### PR TITLE
Extend the fix for ignoring private attributes to subclasses without Abstract in bases

### DIFF
--- a/abstractcp/__init__.py
+++ b/abstractcp/__init__.py
@@ -113,6 +113,10 @@ class Abstract:
             # assumed to be non-abstract, and therefore should have all
             # properties defined
             for name in dir(cls):
+                if name.startswith("__") and name.endswith("__"):
+                    # internal names are ignored since they may have magic attached
+                    # when accessing
+                    continue
                 if isinstance(getattr(cls, name), _AbstractClassProperty):
                     raise TypeError(
                         f"Class {cls.__name__} must define abstract class "

--- a/tests/test_define.py
+++ b/tests/test_define.py
@@ -87,6 +87,24 @@ def test_combine_with_abc_ABC_first():
                                          "with abstract method(?:s?) foo")):
         A()
 
+    with pytest.raises(TypeError, match=("Class B must define abstract class "
+                                         "property i, or have Abstract as "
+                                         "direct parent.")):
+        class B(A):
+            def foo(self):
+                pass
+
+    class C(A):
+        i = 1
+
+        def foo(self):
+            return True
+
+    c = C()
+    assert isinstance(c, A)
+    assert c.i == 1
+    assert c.foo()
+
 def test_combine_with_abc_ABC_second():
     import abc
 
@@ -100,6 +118,24 @@ def test_combine_with_abc_ABC_second():
     with pytest.raises(TypeError, match=("Can't instantiate abstract class A "
                                          "with abstract method(?:s?) foo")):
         A()
+
+    with pytest.raises(TypeError, match=("Class B must define abstract class "
+                                         "property i, or have Abstract as "
+                                         "direct parent.")):
+        class B(A):
+            def foo(self):
+                pass
+
+    class C(A):
+        i = 1
+
+        def foo(self):
+            return True
+
+    c = C()
+    assert isinstance(c, A)
+    assert c.i == 1
+    assert c.foo()
 
 def test_abstract_class_without_abstract_properties():
     with pytest.raises(TypeError, match="Class A is defined as abstract but does "

--- a/tests/test_define.py
+++ b/tests/test_define.py
@@ -73,10 +73,12 @@ def test_multi_level_subclass():
     assert D.b == (1, 2, 3)
     assert D.c == "spam"
 
-def test_combine_with_abc_ABC_first():
+
+@pytest.mark.parametrize("inherit_order", [1, -1])
+def test_combine_with_abc_ABC(inherit_order):
     import abc
 
-    class A(abc.ABC, acp.Abstract):
+    class A(*((abc.ABC, acp.Abstract)[::inherit_order])):
         i: int = acp.abstract_class_property(int)
 
         @abc.abstractmethod
@@ -105,37 +107,6 @@ def test_combine_with_abc_ABC_first():
     assert c.i == 1
     assert c.foo()
 
-def test_combine_with_abc_ABC_second():
-    import abc
-
-    class A(acp.Abstract, abc.ABC):
-        i: int = acp.abstract_class_property(int)
-
-        @abc.abstractmethod
-        def foo(self):
-            ...
-
-    with pytest.raises(TypeError, match=("Can't instantiate abstract class A "
-                                         "with abstract method(?:s?) foo")):
-        A()
-
-    with pytest.raises(TypeError, match=("Class B must define abstract class "
-                                         "property i, or have Abstract as "
-                                         "direct parent.")):
-        class B(A):
-            def foo(self):
-                pass
-
-    class C(A):
-        i = 1
-
-        def foo(self):
-            return True
-
-    c = C()
-    assert isinstance(c, A)
-    assert c.i == 1
-    assert c.foo()
 
 def test_abstract_class_without_abstract_properties():
     with pytest.raises(TypeError, match="Class A is defined as abstract but does "


### PR DESCRIPTION
I found that issue #1 was still occuring with v0.9.7 when I had a parent class (`A`) with `abc.ABC` and `Abstract` as parents, and a subclass of `A` without `Abstract` as a parent. This small change seems to fix it. I extended `test_define.py` slightly to cover this case.